### PR TITLE
Allow st to run outside of git repos

### DIFF
--- a/st.py
+++ b/st.py
@@ -65,9 +65,13 @@ def buildConfig():
 
     config_files = [
         os.path.join(os.path.abspath(os.path.dirname(sys.argv[0])),'stlib','base_config.py'),
-        os.path.join(shell(['git','rev-parse','--show-toplevel']), '.st_config.py'),
-        os.path.join(pathlib.Path.home(),'.st_config.py')
+        os.path.join(pathlib.Path.home(),'.st_config.py'),
     ]
+
+    # If we're in a git repo, see if there's an st config file at the top level
+    repoinfo = stlib.shell.repoinfo()
+    if repoinfo:
+       config_files.append(os.path.join(repoinfo['root'], '.st_config.py'))
 
     configfiles_data = []
     for cfgfile in config_files:

--- a/stlib/shell.py
+++ b/stlib/shell.py
@@ -33,7 +33,7 @@ def shellDetach(what):
 def repoinfo():
     root = shellReturnOutput('git rev-parse --show-toplevel')
     if root is None or re.match(r'fatal',root):
-        util.die('Not in a git repo')
+        return None
 
     url = shellReturnOutput('git config --get remote.origin.url')
     if url is None or re.match(r'fatal',url):


### PR DESCRIPTION
Some st commands like 't' (time), are useful anywhere in the filesystem, even absent a git repo as context. This PR allows such commands to run with any directory as cwd.

Also, some cleanups in time parsing.